### PR TITLE
Implement code coverage (#53)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+minversion = 6.0
+addopts = --cov=cogs --cov=utils

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 discord.py
 psutil
 timeago==1.0.13
+
+# testing support
+pytest
+pytest-cov


### PR DESCRIPTION
Necessary tooling to get test code coverage working per Task #53. Anyone wishing to run coverage reports should run this command from the repo root:

`python -m pip install --user -r requirements.txt` (where `python` is replaced with the invocation for whatever version of python you are using for this project)

This will pick up and install the new testing dependencies on your system, after which running `pytest` should automatically produce a coverage report as shown in the comments of #53.