### PR TITLE
Discord command testing

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,4 @@
+[run]
+include =
+    utils/*
+    cogs/*

--- a/distest-test-bot.py
+++ b/distest-test-bot.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3.7
+
+# Based on the example tester at
+# https://github.com/JakeCover/distest/blob/develop/example_tester.py
+#
+# To run:
+# ./distest-test-bot.py --run all --channel <channel ID> 821891815329890336 <tester token>
+# (821891815329890336 is the user ID of the bot being tested)
+
+import sys
+
+from distest import TestCollector, run_dtest_bot
+
+test = TestCollector()
+
+@test()
+async def test_ping(interface):
+    await interface.assert_reply_contains("!ping", "Pong!")
+
+
+if __name__ == "__main__":
+    run_dtest_bot(sys.argv, test)

--- a/distest-test-bot.py
+++ b/distest-test-bot.py
@@ -6,10 +6,19 @@
 # To run:
 # ./distest-test-bot.py --run all --channel <channel ID> 821891815329890336 <tester token>
 # (821891815329890336 is the user ID of the bot being tested)
+#
+# To run with coverage enabled, run these two commands:
+# coverage run distest-test-bot.py --run all --channel <channel ID> 821891815329890336 <tester token>
+# coverage report
 
+import asyncio
 import sys
+from concurrent.futures import ThreadPoolExecutor
 
 from distest import TestCollector, run_dtest_bot
+from distest.patches import patch_target
+
+# Actual tests
 
 test = TestCollector()
 
@@ -17,6 +26,31 @@ test = TestCollector()
 async def test_reverse(interface):
     await interface.assert_reply_contains("!reverse this class sucks", "skcus ssalc siht")
 
+# Run the tests
 
-if __name__ == "__main__":
-    run_dtest_bot(sys.argv, test)
+async def run_tests():
+    from utils.bot import bot, config
+
+    patch_target(bot)
+
+    def patch_signals(*args, **kwargs):
+        raise NotImplementedError
+
+    loop = asyncio.get_event_loop()
+    loop.add_signal_handler = patch_signals
+
+    def set_loop():
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.add_signal_handler = patch_signals
+
+    with ThreadPoolExecutor(initializer=set_loop) as pool:
+        await asyncio.gather(
+            bot.start(config["token"]),
+            loop.run_in_executor(pool, run_dtest_bot, sys.argv, test)
+        )
+
+    await bot.logout()
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(run_tests())

--- a/distest-test-bot.py
+++ b/distest-test-bot.py
@@ -14,8 +14,8 @@ from distest import TestCollector, run_dtest_bot
 test = TestCollector()
 
 @test()
-async def test_ping(interface):
-    await interface.assert_reply_contains("!ping", "Pong!")
+async def test_reverse(interface):
+    await interface.assert_reply_contains("!reverse this class sucks", "skcus ssalc siht")
 
 
 if __name__ == "__main__":

--- a/index.py
+++ b/index.py
@@ -1,25 +1,6 @@
-import os
-import discord
+from utils.bot import bot, config
 
-from utils import default
-from utils.data import Bot, HelpFormat
-
-config = default.config()
 print("Logging in...")
-
-bot = Bot(
-    command_prefix=config["prefix"], prefix=config["prefix"],
-    owner_ids=config["owners"], command_attrs=dict(hidden=True), help_command=HelpFormat(),
-    intents=discord.Intents(  # kwargs found at https://discordpy.readthedocs.io/en/latest/api.html?highlight=intents#discord.Intents
-        guilds=True, members=True, messages=True, reactions=True, presences=True
-    )
-)
-
-for file in os.listdir("cogs"):
-    if file.endswith(".py"):
-        name = file[:-3]
-        bot.load_extension(f"cogs.{name}")
-
 try:
     bot.run(config["token"])
 except Exception as e:

--- a/utils/bot.py
+++ b/utils/bot.py
@@ -1,0 +1,20 @@
+import os
+import discord
+
+from utils import default
+from utils.data import Bot, HelpFormat
+
+config = default.config()
+
+bot = Bot(
+    command_prefix=config["prefix"], prefix=config["prefix"],
+    owner_ids=config["owners"], command_attrs=dict(hidden=True), help_command=HelpFormat(),
+    intents=discord.Intents(  # kwargs found at https://discordpy.readthedocs.io/en/latest/api.html?highlight=intents#discord.Intents
+        guilds=True, members=True, messages=True, reactions=True, presences=True
+    )
+)
+
+for file in os.listdir("cogs"):
+    if file.endswith(".py"):
+        name = file[:-3]
+        bot.load_extension(f"cogs.{name}")

--- a/utils/data.py
+++ b/utils/data.py
@@ -13,11 +13,21 @@ class Bot(AutoShardedBot):
         self.trivia = Trivia()
 
     async def on_message(self, msg):
-        if not self.is_ready() or msg.author.bot or not permissions.can_handle(msg, "send_messages"):
+        if not self.is_ready() or not permissions.can_handle(msg, "send_messages"):
             return
 
         await self.process_commands(msg)
 
+    ## @story{51} In order to test command coroutines, a second bot is needed.
+    # The default discord.py Bot class does not respond to other bots, so we
+    # must override this method to allow complete testing.
+    async def process_commands(self, message):
+        # Do nothing if sent by a bot that is not the testing bot
+        if message.author.bot and message.author.id != 834537991397572618:
+            return
+
+        ctx = await self.get_context(message)
+        await self.invoke(ctx)
 
 class HelpFormat(DefaultHelpCommand):
     def get_destination(self, no_pm: bool = False):


### PR DESCRIPTION
After a three-hour fight with asyncio, I present Discord command testing as ordered in Task #60. Do not expect to just run the test script and get results. In order to run this, you need:

- the `distest` package installed (using `pip`)
  - note that installing `distest` will **down**grade `discord.py` because `distest` apparently does not work with `discord.py` 1.7 yet
- a second bot user (requires creating another application in the developer portal and adding a bot user with admin permissions and privileged intents)
- a dedicated channel on your private server to run the tests on
- the `coverage` package installed using `pip` (only if you want to produce a test coverage report)

I don't expect everyone to set things up to run this. If you do want to run it, you will need to go into `utils/data.py` line 26 and change the long number to the user ID of the bot running the tests (not of the bot being tested). Then follow the instructions at the top of the test script.

If running it yourself, do not start the main bot separately; the test script will launch the tested bot itself in the same process as the test harness (this is critical as measuring test coverage cannot be done when the bot is running in a completely separate process, perhaps even on a different machine, from the test harness) and shut it down when the tests are complete. Even if you are not running coverage, you should still not start the bot separately because the script launches the bot itself regardless.

A few notes:

- Most of `index.py` was moved into `utils/bot.py`. This was necessary to make it possible to import the bot without automatically starting the infinite `bot.run` loop.
- `distest` is poorly documented, and so finding out how to do things is difficult. The best source for test assertions is the source code itself: https://github.com/JakeCover/distest/tree/develop/distest/TestInterface along with the sample tester in the root of that same repo.
- The changes in `utils/data.py` are required as the discord.py library by default ignores messages from other bots. We do not want the bot to respond to all bots, just the testing bot. The bot ID shown is my own testing bot; unfortunately there's no easy way to not have it hardcoded and I'm done fighting with this. If you want to run with your own testing bot, then as mentioned above, you will need to edit this (and make sure you revert the change. I think for the 9 days left in this semester, that will be okay.